### PR TITLE
remove 'critical' flag on SSL server cert as it breaks Firefox >= 31.0 (...

### DIFF
--- a/include/openssl_functions.php
+++ b/include/openssl_functions.php
@@ -174,7 +174,7 @@ nsCaPolicyUrl          = $config[base_url]$config[policy_url]
 [ server_ext ]
 basicConstraints        = critical, CA:false
 keyUsage                = critical, digitalSignature, keyEncipherment
-nsCertType              = critical, server
+nsCertType              = server
 extendedKeyUsage        = critical, serverAuth
 subjectKeyIdentifier    = hash
 authorityKeyIdentifier  = keyid:always, issuer:always


### PR DESCRIPTION
...info here: https://blog.mozilla.org/security/2014/04/24/exciting-updates-to-certificate-verification-in-gecko/)
